### PR TITLE
Add simple addFile function

### DIFF
--- a/h2o-pp.cc
+++ b/h2o-pp.cc
@@ -153,6 +153,13 @@ void H2OWebserver::addDirectory(const std::string_view path, const std::string_v
   h2o_file_register(pathconf, &directory[0], NULL, NULL, 0);
 }
 
+void H2OWebserver::addFile(const std::string_view path, const std::string_view file, h2o_hostconf_t* hconf)
+{
+  h2o_pathconf_t *pathconf = h2o_config_register_path(hconf ? hconf : d_hostconf, &path[0], 0);
+  h2o_mimemap_type_t *mimetype = h2o_mimemap_get_type_by_extension(d_hostconf->mimemap, h2o_get_filext(&file[0], strlen(&file[1])));
+  h2o_file_register_file(pathconf, &file[0], mimetype, 0);
+}
+
 std::string_view convert(const h2o_iovec_t& vec)
 {
   return std::string_view(vec.base, vec.len);

--- a/h2o-pp.hh
+++ b/h2o-pp.hh
@@ -1,6 +1,6 @@
 #pragma once
 #define H2O_USE_EPOLL 1
-#include "h2o.h"
+#include <h2o.h>
 #include <string>
 #include <functional>
 #include "comboaddress.hh"
@@ -37,6 +37,9 @@ struct H2OWebserver
   
   //! Add a directory to be served on a path. Defaults to adding it to the default host.
   void addDirectory(const std::string_view path, const std::string_view directory, h2o_hostconf_t* hconf=0);
+
+  //! Add a file to be server on a path. Allows hosting of individual file on a virtual path. Defaults to add it to the default host.
+  void addFile(const std::string_view path, const std::string_view file, h2o_hostconf_t* hconf=0);
 
   //! Call this to add a TLS context. Returns an accept context that can be used with addListener
   h2o_accept_ctx_t* addSSLContext(const std::string_view certificate, const std::string_view key, const std::string_view ciphers="");


### PR DESCRIPTION
Might seem a bit strange, but let's say you store all your JS files in a
directory. Now, you want to host your service-worker.js in the root (for
scope reasons). This will allow you to do addFile('/service-worker.js',
'./js/service-worker.js');

This basically is a little bit of url-rewriting for an individual file.

Patch is untested as on debian9 the string_view is in std::experimental.

It would be great if you (ahu) could review is this is actually the right way to do it.